### PR TITLE
Removing the Microsoft.Extensions.Configuration Library

### DIFF
--- a/src/Project.API.User.Repository/Data/UserRepository.cs
+++ b/src/Project.API.User.Repository/Data/UserRepository.cs
@@ -1,5 +1,4 @@
 ﻿using Dapper;
-using Microsoft.Extensions.Configuration;
 using MySql.Data.MySqlClient;
 using Project.API.User.Business.Interface.Repositories;
 using Project.API.User.Repository.Queries;


### PR DESCRIPTION
Removing a library `Microsoft.Extensions.Configuration Library ` that is breaking the build.
